### PR TITLE
fix: Avoid mismatch on React hydration

### DIFF
--- a/src/hooks/useCheckboxes.ts
+++ b/src/hooks/useCheckboxes.ts
@@ -1,3 +1,4 @@
+import React from "react"
 import { useLocalStorage } from "@rehooks/local-storage"
 
 export function useCheckboxes(key: string) {
@@ -17,8 +18,18 @@ export function useCheckboxes(key: string) {
     setChecked({})
   }
 
+  // To avoid a mismatch during hydration, we need to initially render with an
+  // empty state to match the default state of `useLocalStorage()`. After the
+  // first render (via `useEffect`), we copy the state from local storage into
+  // this hook and keep it up to date thereafter. This keeps the state from
+  // `useLocalStorage()` as the source of truth.
+  const [state, setState] = React.useState({})
+  React.useEffect(() => {
+    setState(checked)
+  }, [checked])
+
   return {
-    checked,
+    checked: state,
     clearChecked,
     handleToggle,
   }


### PR DESCRIPTION
Previously, when refreshing the page after checking some ingredients, it rendered in a mixed state:

<img width="336" alt="Screen Shot 2022-01-11 at 1 17 35 PM" src="https://user-images.githubusercontent.com/1476544/149023089-db1e1329-170c-4576-9214-4e83b7925936.png">

This was likely due to a React hydration mismatch, where the server-rendered DOM (no checked items) didn't match what was on the client (1+ checked items). Deferring the reading of state from local storage until after hydration fixes this.